### PR TITLE
Fix GA session number type normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# dbt_ga4_export v0.7.1
+
+[PR #20](https://github.com/fivetran/dbt_ga4_export/pull/20) includes the following updates:
+
+## Bug Fixes
+- Casts `param_ga_session_number` to an integer in the staging event model so session-number fallback logic can coalesce it with derived session indexes when source schemas provide the field as a string.
+
 # dbt_ga4_export v0.7.0
 
 [PR #18](https://github.com/fivetran/dbt_ga4_export/pull/18) includes the following updates:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 [PR #20](https://github.com/fivetran/dbt_ga4_export/pull/20) includes the following updates:
 
 ## Bug Fixes
-- Casts `param_ga_session_number` to an integer in the staging event model so session-number fallback logic can coalesce it with derived session indexes when source schemas provide the field as a string.
+- Casts `param_ga_session_number` to a string in the staging event model so session-number fallback logic can coalesce it with derived session indexes when source schemas provide the field as a string.
 
 # dbt_ga4_export v0.7.0
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 config-version: 2
 name: 'ga4_export'
-version: '0.7.0'
+version: '0.7.1'
 require-dbt-version: [">=1.3.0", "<3.0.0"]
 models:
   ga4_export:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'ga4_export_integration_tests'
-version: '0.7.0'
+version: '0.7.1'
 config-version: 2
 profile: 'integration_tests'
 
@@ -30,6 +30,7 @@ seeds:
   +quote_columns: "{{ true if target.type in ('redshift','postgres') or var('fivetran_using_source_casing', false) else false }}"
   ga4_export_integration_tests:
     +column_types:
+      param_ga_session_number: "{{ 'STRING' if target.type in ('bigquery', 'spark', 'databricks') else 'varchar' }}"
       param_engagement_time_msec: "{{ 'FLOAT64' if target.type == 'bigquery' else 'float' }}"
       stream_id: "{{ 'varchar(100)' if target.type in ('redshift', 'postgres') else 'string' }}"
 

--- a/macros/get_event_columns.sql
+++ b/macros/get_event_columns.sql
@@ -36,7 +36,7 @@
     {"name": "param_medium", "datatype": dbt.type_string()},
     {"name": "param_source", "datatype": dbt.type_string()},
     {"name": "param_ga_session_id", "datatype": dbt.type_string()},
-    {"name": "param_ga_session_number", "datatype": dbt.type_int()},
+    {"name": "param_ga_session_number", "datatype": dbt.type_string()},
     {"name": "param_engagement_time_msec", "datatype": dbt.type_float()},
     {"name": "param_engaged_session_event", "datatype": dbt.type_string()},
     {"name": "param_session_engaged", "datatype": "boolean"},

--- a/macros/get_event_columns.sql
+++ b/macros/get_event_columns.sql
@@ -36,7 +36,7 @@
     {"name": "param_medium", "datatype": dbt.type_string()},
     {"name": "param_source", "datatype": dbt.type_string()},
     {"name": "param_ga_session_id", "datatype": dbt.type_string()},
-    {"name": "param_ga_session_number", "datatype": dbt.type_float()},
+    {"name": "param_ga_session_number", "datatype": dbt.type_int()},
     {"name": "param_engagement_time_msec", "datatype": dbt.type_float()},
     {"name": "param_engaged_session_event", "datatype": dbt.type_string()},
     {"name": "param_session_engaged", "datatype": "boolean"},

--- a/models/intermediate/int_ga4_export__derived_event_fields.sql
+++ b/models/intermediate/int_ga4_export__derived_event_fields.sql
@@ -62,7 +62,7 @@ with event_base as (
         -- Coalesce param_session_engaged or use the derived_is_engaged_event as is_session_engaged
         cast(coalesce(param_session_engaged,derived_is_engaged_event) as boolean) as is_session_engaged,
         -- Coalesce param_ga_session_number or use the derived_session_index as the session_number
-        cast(coalesce(param_ga_session_number, derived_session_index) as {{ dbt.type_string() }}) as session_number
+        coalesce(param_ga_session_number, cast(derived_session_index as {{ dbt.type_string() }})) as session_number
 
     from derived_events
 

--- a/models/staging/stg_ga4_export__event.sql
+++ b/models/staging/stg_ga4_export__event.sql
@@ -58,7 +58,7 @@ final as (
         param_medium,
         param_source,
         cast(param_ga_session_id as {{ dbt.type_string() }}) as param_ga_session_id,
-        param_ga_session_number,
+        cast(param_ga_session_number as {{ dbt.type_int() }}) as param_ga_session_number,
         cast(param_engagement_time_msec as {{ dbt.type_float() }}) as param_engagement_time_msec,
         param_engaged_session_event,
         cast(param_session_engaged as boolean) as param_session_engaged,

--- a/models/staging/stg_ga4_export__event.sql
+++ b/models/staging/stg_ga4_export__event.sql
@@ -58,7 +58,7 @@ final as (
         param_medium,
         param_source,
         cast(param_ga_session_id as {{ dbt.type_string() }}) as param_ga_session_id,
-        cast(param_ga_session_number as {{ dbt.type_int() }}) as param_ga_session_number,
+        cast(param_ga_session_number as {{ dbt.type_string() }}) as param_ga_session_number,
         cast(param_engagement_time_msec as {{ dbt.type_float() }}) as param_engagement_time_msec,
         param_engaged_session_event,
         cast(param_session_engaged as boolean) as param_session_engaged,


### PR DESCRIPTION
**Please provide your name and company**

Yuri Cavalcanti — independent contributor

**Link the issue/feature request which this PR is meant to address**

Fixes #19

**Detail what changes this PR introduces and how this addresses the issue/feature request linked above.**

This PR normalizes `param_ga_session_number` in the staging event model by casting it to `dbt.type_string()`. It also casts `derived_session_index` to `dbt.type_string()` before the fallback coalesce in `int_ga4_export__derived_event_fields`.

This keeps the session-number fallback logic type-compatible when source schemas provide `param_ga_session_number` as a string, while preserving the downstream behavior where `session_number` is used as part of `session_id` generation.

It also updates `get_event_columns()` so the expected type for `param_ga_session_number` matches the staging model, and adjusts the integration test seed column type to exercise the regression case where the source provides `param_ga_session_number` as a string.

**How did you validate the changes introduced within this PR?**

Validated locally with DuckDB because BigQuery credentials were not available in this environment.

Before the fix, the selected integration run reproduced the same class of failure when `param_ga_session_number` was seeded as `varchar`:

```text
Binder Error: Cannot mix values of type VARCHAR and HUGEINT in COALESCE operator - an explicit cast is required
```

After the fix, the full integration build passed:

```bash
../.venv/bin/dbt build --profiles-dir /private/tmp/dbt_ga4_export_profiles --vars '{ga4_export_schema: main}'
```

Result:

```text
PASS=13 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=13
```

**Which warehouse did you use to develop these changes?**

DuckDB for local validation. The issue was reported against BigQuery, and the fix uses dbt type macros rather than warehouse-specific SQL.

**Did you update the CHANGELOG?**

- [x] Yes

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)**

- [x] Yes

**Typically there are additional maintenance changes required before this will be ready for an upcoming release. Are you comfortable with the Fivetran team making a few commits directly to your branch?**

- [x] Yes
- [ ] No

**If you had to summarize this PR in an emoji, which would it be?**

:wrench: